### PR TITLE
[Testing] Use teapot status code

### DIFF
--- a/doer_test.go
+++ b/doer_test.go
@@ -24,7 +24,7 @@ func (m *mockDoer) Do(req *http.Request) (*http.Response, error) {
 
 func TestMockDo(t *testing.T) {
 	// Use a status code that does not exist in the wild
-	code := 1337
+	code := 418
 	m := mockDoer{
 		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(code)


### PR DESCRIPTION
The version of Go on CircleCI does not like the `1337` status code.
