### PR TITLE
[Messenger] Add token verifier

### DIFF
--- a/verfier.go
+++ b/verfier.go
@@ -1,0 +1,22 @@
+package aural
+
+import (
+	"net/http"
+)
+
+type verifier struct {
+	token string
+}
+
+func (v verifier) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("hub.verify_token") == v.token {
+		w.Write([]byte(r.URL.Query().Get("hub.challenge")))
+	} else {
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	}
+}
+
+// NewVerifier creates a Facebook Messenger token verifier
+func NewVerifier(token string) http.Handler {
+	return &verifier{token}
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -1,0 +1,27 @@
+package aural_test
+
+import (
+	"github.com/pspeter3/aural"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInvalidToken(t *testing.T) {
+	v := aural.NewVerifier("token")
+	r, err := http.NewRequest(http.MethodGet, "/?hub.verify_token=evil", nil)
+	ok(t, err)
+	w := httptest.NewRecorder()
+	v.ServeHTTP(w, r)
+	equals(t, w.Code, http.StatusUnauthorized)
+}
+
+func TestValidToken(t *testing.T) {
+	v := aural.NewVerifier("token")
+	r, err := http.NewRequest(http.MethodGet, "/?hub.verify_token=token&hub.challenge=foo", nil)
+	ok(t, err)
+	w := httptest.NewRecorder()
+	v.ServeHTTP(w, r)
+	equals(t, w.Code, http.StatusOK)
+	equals(t, w.Body.String(), "foo")
+}


### PR DESCRIPTION
This is used to verify tokens from webhooks. These are sent by Facebook
when connecting the app.
