### PR TITLE
[Messenger] Change UserID to uint64

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -22,7 +22,7 @@ func TestDispatcher_BadRequest(t *testing.T) {
 
 func TestDispatcher_ServeHTTP(t *testing.T) {
 	user := aural.User{
-		ID: aural.UserID("1"),
+		ID: aural.UserID(1),
 	}
 	m := mockDoer{http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		equals(t, r.URL.Path, "/v1/search")
@@ -42,7 +42,7 @@ func TestDispatcher_ServeHTTP(t *testing.T) {
 			"messaging": [
 				{
 					"sender": {
-						"id": "1"
+						"id": 1
 					},
 					"message": {
 						"text": "Does Not Exist"

--- a/process_test.go
+++ b/process_test.go
@@ -32,7 +32,7 @@ func testAction(t *testing.T, method string, entityType string) {
 		w.Write([]byte(fmt.Sprintf(`{"%s":{"items":[]}}`, entityType)))
 	})}
 	user := aural.User{
-		ID: aural.UserID("1"),
+		ID: aural.UserID(1),
 	}
 	s := mockSender{
 		t:    t,
@@ -81,7 +81,7 @@ func TestProcess_SearchArtists(t *testing.T) {
 		w.Write([]byte(`{"artist":{"items":[]}}`))
 	})}
 	user := aural.User{
-		ID: aural.UserID("1"),
+		ID: aural.UserID(1),
 	}
 	s := mockSender{
 		t:    t,

--- a/sender_test.go
+++ b/sender_test.go
@@ -12,14 +12,14 @@ func TestSender_Send(t *testing.T) {
 	token := "token"
 	sender := aural.NewSender(token)
 	user := aural.User{
-		ID: aural.UserID("1"),
+		ID: aural.UserID(1),
 	}
 	m := mockDoer{http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		equals(t, r.URL.Path, "/v2.6/me/messages")
 		equals(t, r.URL.Query().Get("access_token"), token)
 		body, err := ioutil.ReadAll(r.Body)
 		ok(t, err)
-		expected := `{"recipient":{"id":"1"},"message":{"attachment":{"type":"template","payload":{"template_type":"generic","elements":[]}}}}`
+		expected := `{"recipient":{"id":1},"message":{"attachment":{"type":"template","payload":{"template_type":"generic","elements":[]}}}}`
 		assert(t, strings.EqualFold(string(body), expected), "Bodies are not the same")
 	})}
 	sender.Send(m, user, []aural.Element{})

--- a/user.go
+++ b/user.go
@@ -1,7 +1,7 @@
 package aural
 
 // UserID is a type alias for UserIDs provided by the Facebook API
-type UserID string
+type UserID uint64
 
 // User is a struct for User objects provided by the Facebook API
 type User struct {


### PR DESCRIPTION
The Facebook API made it seem like the IDs were strings but they are
numbers instead.
